### PR TITLE
fix: updated GH Action to set S3 files to public read

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm run build:svench
       - uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}


### PR DESCRIPTION
S3 files did not have public access when deployed - hence 403s 

This also
- deletes old build files from the bucket
- "fixes some weird symbolic link problems that may come up." (https://github.com/jakejarvis/s3-sync-action)