### PR TITLE
fix: removed width, so we can set maxWidth via prop

### DIFF
--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -51,7 +51,6 @@
     outline: none;
     box-sizing: border-box;
     opacity: 0;
-    width: 400px;
     min-width: 200px;
     min-height: 200px;
     color: var(--ink);

--- a/src/Modal/Modal.svench
+++ b/src/Modal/Modal.svench
@@ -6,17 +6,26 @@
   import Body from "../Styleguide/Body.svelte";
   import Logo from "../Styleguide/Logo.svelte";
   import Content from "./Content.svelte";
-  let modal
+  let modalDefault
+  let modalmaxWidth
 </script>
 
 <style>
 
 </style>
 
-<View name="Modal">
-  <Button primary on:click={modal.show}>Show Modal</Button>
+<View name="Modal Default">
+  <Button primary on:click={modalDefault.show}>Show Modal</Button>
 
-  <Modal bind:this={modal}>
+  <Modal bind:this={modalDefault}>
+    <Content />
+  </Modal>
+</View>
+
+<View name="Modal with max width">
+  <Button primary on:click={modalmaxWidth.show}>Show Modal</Button>
+
+  <Modal bind:this={modalmaxWidth} maxWidth="400px">
     <Content />
   </Modal>
 </View>


### PR DESCRIPTION
the `width` was set, and was stopping the Modal to grow to it's `max-width`. removed this, and added an exmple of how to use the `maxWidth` property