### PR TITLE
fix: adding min-width prop to modal & adding Spacer component to exports

### DIFF
--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -1,11 +1,12 @@
 <script>
   import { createEventDispatcher } from "svelte";
-  import buildStyle from "../utils/buildStyle"
-  import { fade } from 'svelte/transition';
+  import buildStyle from "../utils/buildStyle";
+  import { fade } from "svelte/transition";
 
   const dispatch = createEventDispatcher();
   export let maxWidth = "30vw";
   export let maxHeight = "60vh";
+  export let minWidth = "30vw";
   export let borderColor = "";
 
   export const show = () => {
@@ -29,7 +30,8 @@
   $: containerStyle = buildStyle({
     "max-height": maxHeight,
     "max-width": maxWidth,
-    borderColor,
+    "min-width": minWidth,
+    borderColor
   });
 </script>
 
@@ -100,20 +102,17 @@
     background-color: var(--grey-4);
     cursor: pointer;
   }
-
 </style>
 
-{#if open}  
-  <div on:click|self={hide} class="overlay" transition:fade="{{ duration: 200 }}">
+{#if open}
+  <div on:click|self={hide} class="overlay" transition:fade={{ duration: 200 }}>
     <div
       tabindex="0"
       class:open
       style={containerStyle}
       on:keydown={handleEscape}
       class="container">
-      <button on:click={hide} class="close">
-        ×
-      </button>
+      <button on:click={hide} class="close">×</button>
       <slot />
     </div>
   </div>

--- a/src/Modal/Modal.svench
+++ b/src/Modal/Modal.svench
@@ -6,8 +6,8 @@
   import Body from "../Styleguide/Body.svelte";
   import Logo from "../Styleguide/Logo.svelte";
   import Content from "./Content.svelte";
-  let modalDefault
-  let modalmaxWidth
+  let modalDefault;
+  let modalmaxWidth;
 </script>
 
 <style>
@@ -18,6 +18,14 @@
   <Button primary on:click={modalDefault.show}>Show Modal</Button>
 
   <Modal bind:this={modalDefault}>
+    <Content />
+  </Modal>
+</View>
+
+<View name="Modal with min width">
+  <Button primary on:click={modalmaxWidth.show}>Show Modal</Button>
+
+  <Modal bind:this={modalmaxWidth} minWidth="600px">
     <Content />
   </Modal>
 </View>

--- a/src/Modal/Modal.svench
+++ b/src/Modal/Modal.svench
@@ -22,7 +22,7 @@
   </Modal>
 </View>
 
-<View name="Modal with min width">
+<View name="Modal with Min Width">
   <Button primary on:click={modalmaxWidth.show}>Show Modal</Button>
 
   <Modal bind:this={modalmaxWidth} minWidth="600px">
@@ -30,7 +30,7 @@
   </Modal>
 </View>
 
-<View name="Modal with max width">
+<View name="Modal with Max Width">
   <Button primary on:click={modalmaxWidth.show}>Show Modal</Button>
 
   <Modal bind:this={modalmaxWidth} maxWidth="400px">

--- a/src/index.js
+++ b/src/index.js
@@ -24,4 +24,4 @@ export { default as Heading } from "./Styleguide/Heading.svelte";
 export { default as Label } from "./Styleguide/Label.svelte";
 export { default as Close } from "./Button/Close.svelte";
 export { default as Modal } from "./Modal/Modal.svelte";
-
+export { default as Spacer } from "./Spacer/Spacer.svelte";


### PR DESCRIPTION
Adding minWidth to modal
Adding Spacer to exports 


<img width="805" alt="Screen Shot 2020-09-03 at 09 11 36" src="https://user-images.githubusercontent.com/9913651/92089214-bfc63680-edc5-11ea-9e64-c89912324b03.png">

