### PR TITLE
fix: don't render empty textarea labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 /dist/
 /public/svench/
+.idea

--- a/src/Form/TextArea.svelte
+++ b/src/Form/TextArea.svelte
@@ -91,17 +91,19 @@
 </style>
 
 <div class="container">
-  <label class:thin for={name}>
-    {#if label}{label}{/if}
-    {#if edit}
-      <div class="right">
-        <Button small secondary disabled={editMode} on:click={enableEdit}>
-          Edit
-        </Button>
-        <Button small blue disabled={!editMode} on:click={save}>Save</Button>
-      </div>
-    {/if}
-  </label>
+  {#if label || edit}
+    <label class:thin for={name}>
+      {#if label}{label}{/if}
+      {#if edit}
+        <div class="right">
+          <Button small secondary disabled={editMode} on:click={enableEdit}>
+            Edit
+          </Button>
+          <Button small blue disabled={!editMode} on:click={save}>Save</Button>
+        </div>
+      {/if}
+    </label>
+  {/if}
   <textarea
     class:thin
     bind:value


### PR DESCRIPTION
Don't render the outermost label component when neither a label or the "edit" prop are specified. This removes the whitespace that currently exists when neither prop are specified.

Also just adds webstorm config to gitignore.