### PR TITLE
fix: reinstated default padding to modal

### DIFF
--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -10,6 +10,10 @@
   export let borderColor = "";
   export let hideCloseButton = false;
 
+  // by default, all modals have padding
+  // use <Modal noPadding> ... </Modal> to remove
+  export let noPadding=false;
+
   export const show = () => {
     dispatch("open");
     open = true;
@@ -48,6 +52,10 @@
     left: 0;
     z-index: 1;
     background: rgba(0, 0, 0, 0.6);
+  }
+  
+  .padding {
+    padding: var(--layout-xs);
   }
 
   .container {
@@ -108,6 +116,7 @@
       class:open
       style={containerStyle}
       on:keydown={handleEscape}
+      class:padding={!noPadding}
       class="container">
       {#if !hideCloseButton}
       <button on:click={hide} class="close">

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -9,10 +9,7 @@
   export let minWidth = "30vw";
   export let borderColor = "";
   export let hideCloseButton = false;
-
-  // by default, all modals have padding
-  // use <Modal noPadding> ... </Modal> to remove
-  export let noPadding=false;
+  export let padding="var(--layout-xs)";
 
   export const show = () => {
     dispatch("open");
@@ -36,7 +33,8 @@
     "max-height": maxHeight,
     "max-width": maxWidth,
     "min-width": minWidth,
-    borderColor
+    borderColor,
+    padding,
   });
 </script>
 
@@ -52,10 +50,6 @@
     left: 0;
     z-index: 1;
     background: rgba(0, 0, 0, 0.6);
-  }
-  
-  .padding {
-    padding: var(--layout-xs);
   }
 
   .container {
@@ -116,7 +110,6 @@
       class:open
       style={containerStyle}
       on:keydown={handleEscape}
-      class:padding={!noPadding}
       class="container">
       {#if !hideCloseButton}
       <button on:click={hide} class="close">

--- a/src/Modal/Modal.svench
+++ b/src/Modal/Modal.svench
@@ -12,6 +12,18 @@
 
 <style>
 
+.custom-padding {
+  background-color: var(--purple);
+  padding: var(--layout-m);
+}
+
+.custom-padding > div {
+  background-color: white;
+  border-radius: var(--border-radius-m);
+  padding: var(--layout-s);
+
+}
+
 </style>
 
 <View name="Modal Default">
@@ -35,5 +47,17 @@
 
   <Modal bind:this={modalmaxWidth} maxWidth="400px">
     <Content />
+  </Modal>
+</View>
+
+<View name="Modal with no padding">
+  <Button primary on:click={modalmaxWidth.show}>Show Modal</Button>
+
+  <Modal bind:this={modalmaxWidth} noPadding maxWidth="400px">
+    <div class="custom-padding">
+      <div>
+        <Content />
+      </div>
+    </div>
   </Modal>
 </View>

--- a/src/Modal/Modal.svench
+++ b/src/Modal/Modal.svench
@@ -50,10 +50,10 @@
   </Modal>
 </View>
 
-<View name="Modal with no padding">
+<View name="Modal with custom padding">
   <Button primary on:click={modalmaxWidth.show}>Show Modal</Button>
 
-  <Modal bind:this={modalmaxWidth} noPadding maxWidth="400px">
+  <Modal bind:this={modalmaxWidth} padding="0" maxWidth="400px">
     <div class="custom-padding">
       <div>
         <Content />


### PR DESCRIPTION
Added a default padding to Modals.

If we need custom padding, we can use `<Modal noPadding> ... </Modal>`,  the set the padding on the content