### PR TITLE
feat: allow inputs to respect type=number

### DIFF
--- a/src/Form/Input.svelte
+++ b/src/Form/Input.svelte
@@ -18,7 +18,12 @@
   let editMode = false;
 
   const updateValue = (e) => {
-    value = e.target.value;
+    if (type === "number") {
+      const num = parseFloat(e.target.value)
+      value = isNaN(num) ? "" : num;
+    } else {
+      value = e.target.value;
+    }
   };
 
   const save = () => {
@@ -92,7 +97,7 @@
   }
   .right :global(button) {
     min-width: 100px;
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-s);
     border-radius: var(--rounded-small);
   }
   .error {
@@ -119,14 +124,12 @@
   {/if}
   <input
     class:thin
-    on:change
-    on:input
     on:change={updateValue}
     on:input={updateValue}
     on:blur={updateValue}
     use:validator
     disabled={disabled || (edit && !editMode)}
-    value={value || ''}
+    value={value}
     {type}
     {name}
     {placeholder} />

--- a/src/Form/Input.svench
+++ b/src/Form/Input.svench
@@ -16,6 +16,10 @@
   <Input thin placeholder="Enter your name" label="Name" />
 </View>
 
+<View name="number">
+  <Input type="number" placeholder="Enter your age" label="Age" />
+</View>
+
 <View name="with edit buttons">
   <Input
     thin


### PR DESCRIPTION
This makes inputs respect `type="number"`. Rather than outputting a string value, binding to the value of an input with `type="number"` will actually bind a numerical value. The default empty state has not been changed however to maintain consistency, and as such is still an empty string `""`.