### PR TITLE
fix: add back in event handlers that were removed by mistake

### DIFF
--- a/src/Form/Input.svelte
+++ b/src/Form/Input.svelte
@@ -124,12 +124,14 @@
   {/if}
   <input
     class:thin
+    on:change
+    on:input
     on:change={updateValue}
     on:input={updateValue}
     on:blur={updateValue}
     use:validator
     disabled={disabled || (edit && !editMode)}
-    value={value}
+    {value}
     {type}
     {name}
     {placeholder} />


### PR DESCRIPTION
Lesson learned here is that svelte components can have multiple handlers for the same event without overriding each other.

For example the following allows binding to native `on:change` events, as well as firing a custom handler.
```
...
on:change
on:change={handler}
...
```

This was the case in the `Input` component and I removed the first `on:change` handler thinking it was redundant and would just be overridden by the second one as typical prop overriding would work.

Lesson learned!
