### PR TITLE
fix: render nullish input values as empty string

### DIFF
--- a/src/Form/Input.svelte
+++ b/src/Form/Input.svelte
@@ -131,7 +131,7 @@
     on:blur={updateValue}
     use:validator
     disabled={disabled || (edit && !editMode)}
-    {value}
+    value={value == null ? "" : value}
     {type}
     {name}
     {placeholder} />


### PR DESCRIPTION
Another tiny magic bug which was not appearing in the svelte REPL. It's such an edge case but...

If you `bind:value` to 2 different components, 1 `Input` and 1 `TextArea`, clearing the `TextArea` somehow sets a value of `undefined` to the `Input`, overriding the default prop and showing the literal string `undefined` in the `Input`. Attempting this manually with any combination of `null` or `undefined` value props to the input fails to reproduce it but anyway, this will just ensure nullish values can never be rendered.

Previously there was a similar statement to this but it was checking for falsiness via `||` which would have now failed anyway to be fair, due to numerical 0 now being a potential value.