### PR TITLE
fix: incorrect font-size css variables for h5 and h6 elements

### DIFF
--- a/.svench/svench.css
+++ b/.svench/svench.css
@@ -159,7 +159,7 @@ h4 {
 }
 
 h5 {
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-l);
   font-family: var(--font-sans);
   font-weight: 500;
   text-rendering: var(--text-render);
@@ -168,7 +168,7 @@ h5 {
 }
 
 h6 {
-  font-size: var(--font-size-md);
+  font-size: var(--font-size-m);
   font-family: var(--font-sans);
   font-weight: 500;
   text-rendering: var(--text-render);


### PR DESCRIPTION
Replacing incorrect css variables from `--font-size-lg` and `--font-size-md` to `--font-size-l` and `--font-size-m` respectively. `h5` elements are used extensilvely in the builder and currently these incorrect variables are causing inconsistencies in sizing.