### PR TITLE
feat: standardise form styles

### DIFF
--- a/.svench/svench.css
+++ b/.svench/svench.css
@@ -121,7 +121,8 @@ h6.svench-content {
   --border-black: 3px var(--black) solid;
   --border-dark: 2px var(--grey-7) solid;
   --border-light: 1px var(--grey-3) solid;
-
+  --border-blue: 2px var(--blue) solid;
+  --border-transparent: 2px transparent solid;
 }
 
 h1 {

--- a/public/index.html
+++ b/public/index.html
@@ -1,13 +1,16 @@
-<!DOCTYPE html />
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-  <title>Svench app</title>
+  <title>BBUI Svench</title>
 
   <link rel="icon" type="image/png" href="/favicon.png" />
+
+  <!--  Custom fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
 
   <!-- Our theme (from .svench/svench.css) -->
   <link rel="stylesheet" href="/svench/theme.css" />

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,4 @@
 import * as path from 'path'
-import * as fs from 'fs'
 import svelte from 'rollup-plugin-svelte-hot'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
@@ -8,7 +7,6 @@ import hmr from 'rollup-plugin-hot'
 import del from 'rollup-plugin-delete'
 import postcss from 'rollup-plugin-postcss-hot'
 import { plugin as Svench } from 'svench/rollup'
-import addClasses from 'rehype-add-classes'
 
 import pkg from './package.json'
 
@@ -27,13 +25,17 @@ const svench = Svench({
   // The root dir that Svench will parse and watch.
   dir: 'src',
 
-  extensions: ['.svench', '.svench.svelte', '.svench.svx'],
+  // Use custom index.html
+  index: {
+    source: "public/index.html"
+  },
 
+  extensions: ['.svench', '.svench.svelte', '.svench.svx'],
   serve: WATCH && {
-    host: 'localhost',
+    host: '0.0.0.0',
     port: 4242,
     public: 'public',
-    nollup: 'localhost:42421',
+    nollup: '0.0.0.0:42421',
   },
 })
 
@@ -83,6 +85,7 @@ const configs = {
 
       HOT &&
       hmr({
+        host: "0.0.0.0",
         public: 'public',
         inMemory: true,
         compatModuleHot: !HOT, // for terser

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -7,8 +7,10 @@
     enableTime: true
   };
 
+  export let label;
   export let placeholder;
   export let value;
+  export let thin = false;
 </script>
 
 <style>
@@ -21,10 +23,23 @@
     border: none;
     background-color: var(--grey-2);
     padding: var(--spacing-m);
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-s);
     margin: 0;
-    outline-color: var(--blue);
+    outline: none;
+    border: var(--border-transparent);
+  }
+  :global(.flatpickr-input:focus) {
+    border: var(--border-blue);
+  }
+
+  div.thin :global(.flatpickr-input) {
+    font-size: var(--font-size-xs);
   }
 </style>
 
-<Flatpickr {placeholder} options={PICKER_OPTIONS} on:change bind:value />
+<div class:thin>
+  {#if label}
+    <Label extraSmall grey>{label}</Label>
+  {/if}
+  <Flatpickr {placeholder} options={PICKER_OPTIONS} on:change bind:value />
+</div>

--- a/src/DatePicker/DatePicker.svench
+++ b/src/DatePicker/DatePicker.svench
@@ -8,6 +8,10 @@
   }
 </script>
 
-<View name="Date Picker">
-  <DatePicker on:change={handleChange} />
+<View name="default">
+  <DatePicker on:change={handleChange} label="Start Date" placeholder="Pick a date" />
+</View>
+
+<View name="thin">
+  <DatePicker on:change={handleChange} label="Start Date" thin placeholder="Pick a date" />
 </View>

--- a/src/Form/DataList.svelte
+++ b/src/Form/DataList.svelte
@@ -1,7 +1,9 @@
 <script>
   import Icon from "../Icons/Icon.svelte";
+  import Label from "../Styleguide/Label.svelte";
   import { createEventDispatcher } from "svelte";
 
+  export let label = undefined;
   export let value = "";
   export let name = undefined;
   export let thin = false;
@@ -10,31 +12,59 @@
   export let disabled = false;
 
   const dispatch = createEventDispatcher();
+  let focus = false
 
   const updateValue = e => {
     value = e.target.value;
   };
+
+  function handleFocus(e) {
+    focus = true;
+    dispatch("focus", e);
+  }
+
+  function handleBlur(e) {
+    focus = false;
+    dispatch("blur", e);
+  }
+
+  $: console.log(value)
 </script>
 
 <style>
+  .container {
+    position: relative !important;
+    display: block;
+    border-radius: var(--border-radius-s);
+    border: var(--border-transparent);
+  }
+  .container.outline {
+    border: var(--border-dark);
+  }
+  .container.focus {
+    border: var(--border-blue);
+  }
+
+  input,
+  select {
+    border-radius: var(--border-radius-s);
+    font-size: var(--font-size-m);
+    outline: none;
+    border: none;
+    color: var(--ink);
+    text-align: left;
+  }
   select {
     display: block !important;
     width: 100% !important;
-    border-radius: var(--border-radius-s);
-    border: none;
-    text-align: left;
-    color: var(--ink);
-    font-size: var(--font-size-m);
     padding: var(--spacing-m) 2rem var(--spacing-m) var(--spacing-m) !important;
     appearance: none !important;
     -webkit-appearance: none !important;
     -moz-appearance: none !important;
     align-items: center;
     white-space: pre;
-    outline-color: var(--blue);
     opacity: 0;
   }
-
   input {
     position: absolute;
     top: 0;
@@ -42,39 +72,23 @@
     width: calc(100% - 50px);
     height: 100%;
     border: none;
-    text-align: left;
-    color: var(--ink);
-    font-size: var(--font-size-m);
     box-sizing: border-box;
-    padding: var(--spacing-s) 0 var(--spacing-m) var(--spacing-m);
-    border-radius: var(--border-radius-s);
+    padding: var(--spacing-m) 0 var(--spacing-m) var(--spacing-m);
   }
 
   select.thin,
   input.thin {
-    padding: var(--spacing-m);
     font-size: var(--font-size-xs);
   }
   .secondary {
     background: var(--grey-2);
   }
 
-  .outline {
-    border: var(--border-dark);
-  }
-
   select:disabled,
   input:disabled,
   .disabled {
     background: var(--grey-4);
-    border: 1px solid var(--grey-4);
     color: var(--grey-6);
-  }
-
-  .relative {
-    position: relative !important;
-    display: block;
-    border-radius: var(--border-radius-s);
   }
 
   .pointer {
@@ -96,14 +110,18 @@
   }
 </style>
 
-<div class="relative" class:disabled class:secondary class:outline>
+{#if label}
+  <Label extraSmall grey forAttr={name}>{label}</Label>
+{/if}
+<div class="container" class:disabled class:secondary class:outline class:focus>
   <select
     {name}
     class:thin
     class:secondary
     {disabled}
     on:change
-    on:blur
+    on:focus={handleFocus}
+    on:blur={handleBlur}
     bind:value>
     <slot />
   </select>
@@ -114,14 +132,14 @@
     class:disabled
     on:change={updateValue}
     on:input={updateValue}
+    on:focus={handleFocus}
     on:blur={e => {
       updateValue(e);
-      dispatch('blur', e);
+      handleBlur(e);
     }}
-    value={value || ''}
+    value={value || ""}
     type="text" />
   <div class="pointer editable-pointer">
     <Icon name="arrowdown" />
   </div>
-
 </div>

--- a/src/Form/DataList.svench
+++ b/src/Form/DataList.svench
@@ -1,65 +1,50 @@
 <script>
   import { View } from "svench";
   import Select from "./Select.svelte";
+  import DataList from "./DataList.svelte";
   import Spacer from "../Spacer/Spacer.svelte"
 
   const options = ["Chocolate", "Vanilla", "Strawberry Cheesecake"];
 </script>
 
 <View name="default">
-  <Select name="Test">
+  <DataList name="Test" label="Flavour">
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}
-  </Select>
+  </DataList>
 </View>
 
 <View name="secondary">
-  <Select secondary name="Test">
+  <DataList secondary name="Test" label="Flavour">
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}
-  </Select>
+  </DataList>
 </View>
 
 <View name="outline">
-  <Select outline name="Test">
+  <DataList outline name="Test" label="Flavour">
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}
-  </Select>
+  </DataList>
 </View>
 
 <View name="disabled">
-  <Select disabled name="Test">
+  <DataList disabled name="Test" label="Flavour">
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}
-  </Select>
-
-  <Spacer medium />
-
-  <Select disabled name="Test">
-    {#each options as option}
-      <option value={option}>{option}</option>
-    {/each}
-  </Select>
+  </DataList>
 </View>
 
 <View name="thin">
-  <Select thin name="Test">
+  <DataList thin name="Test" label="Flavour">
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}
-  </Select>
-
-  <Spacer medium />
-
-  <Select thin name="Test">
-    {#each options as option}
-      <option value={option}>{option}</option>
-    {/each}
-  </Select>
+  </DataList>
 </View>
 
 

--- a/src/Form/Input.svelte
+++ b/src/Form/Input.svelte
@@ -1,6 +1,7 @@
 <script>
   import { createEventDispatcher } from "svelte";
   import Button from "../Button/Button.svelte";
+  import Label from "../Styleguide/Label.svelte"
   const dispatch = createEventDispatcher();
 
   export let name = undefined;
@@ -43,24 +44,31 @@
     min-width: 0;
     display: flex;
     flex-direction: column;
-    font-size: var(--font-size-s);
-    font-family: sans-serif;
-    font-weight: 500;
   }
 
-  label {
-    color: var(--ink);
-    margin-bottom: var(--spacing-s);
+  .label-container {
     display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: var(--spacing-s);
+  }
+  .label-container :global(label) {
+    margin-bottom: 0;
   }
 
-  .right {
+  .controls {
     align-items: center;
     display: grid;
     grid-template-columns: auto auto;
     grid-gap: 12px;
     margin-left: auto;
     padding-left: 12px;
+  }
+  .controls :global(button) {
+    min-width: 100px;
+    font-size: var(--font-size-s);
+    border-radius: var(--rounded-small);
   }
 
   input {
@@ -73,64 +81,52 @@
     background-color: var(--grey-2);
     padding: var(--spacing-m);
     margin: 0;
-    outline-color: var(--blue);
+    outline: none;
     font-family: var(--font-sans);
+    border: var(--border-transparent);
   }
-
-  input::placeholder {
-    color: var(--grey-6);
-  }
-
-  input:focus {
-    box-shadow: 0 4px 16px 0 rgba(57, 60, 68, 0.08);
-  }
-
-  input:disabled {
-    background: var(--grey-4);
-  }
-
-
-
   input.thin {
-    padding: var(--spacing-m);
     font-size: var(--font-size-xs);
   }
-
-  .outline {
+  input.outline {
     border: var(--border-dark);
     background: white;
   }
-
+  input::placeholder {
+    color: var(--grey-6);
+  }
+  input:focus {
+    border: var(--border-blue);
+  }
   input:disabled {
     background: var(--grey-4);
     color: var(--grey-5);
   }
-  .right :global(button) {
-    min-width: 100px;
-    font-size: var(--font-size-s);
-    border-radius: var(--rounded-small);
-  }
+
   .error {
     margin-top: 10px;
-    font-size: 12px;
+    font-size: var(--font-size-xs);
+    font-family: var(--font-sans);
     line-height: 1.17;
     color: var(--red);
   }
 </style>
 
 <div class="container">
-  {#if label}
-    <label class:thin for={name}>
-      {label}
+  {#if label || edit}
+    <div class="label-container">
+      {#if label}
+        <Label extraSmall grey forAttr={name}>{label}</Label>
+      {/if}
       {#if edit}
-        <div class="right">
+        <div class="controls">
           <Button small secondary disabled={editMode} on:click={enableEdit}>
             Edit
           </Button>
           <Button small blue disabled={!editMode} on:click={save}>Save</Button>
         </div>
       {/if}
-    </label>
+    </div>
   {/if}
   <input
     class:outline

--- a/src/Form/Select.svelte
+++ b/src/Form/Select.svelte
@@ -1,11 +1,14 @@
 <script>
+  import Icon from "../Icons/Icon.svelte";
+  import Label from "../Styleguide/Label.svelte";
+
   export let value = "";
   export let name = undefined;
+  export let label = undefined;
   export let thin = false;
   export let secondary = false;
   export let outline = false;
   export let disabled = false;
-  import Icon from "../Icons/Icon.svelte";
 </script>
 
 <style>
@@ -24,23 +27,24 @@
     -moz-appearance: none !important;
     align-items: center;
     white-space: pre;
-    outline-color: var(--blue);
+    outline: none;
+    border: var(--border-transparent);
   }
   select.thin {
     padding: var(--spacing-m);
     font-size: var(--font-size-xs);
   }
-  .secondary {
+  select.secondary {
     background: var(--grey-2);
   }
-
-  .outline {
+  select.outline {
     border: var(--border-dark);
   }
-
+  select:focus {
+    border: var(--border-blue);
+  }
   select:disabled {
     background: var(--grey-4);
-    border: 1px solid var(--grey-4);
     color: var(--grey-6);
   }
 
@@ -61,6 +65,9 @@
   }
 </style>
 
+{#if label}
+  <Label extraSmall grey forAttr={name}>{label}</Label>
+{/if}
 <div class="relative">
   <select
     {name}

--- a/src/Form/Select.svench
+++ b/src/Form/Select.svench
@@ -7,7 +7,8 @@
 </script>
 
 <View name="default">
-  <Select name="Test">
+  <Select name="Test" label="Flavour">
+    <option value="">Choose an option</option>
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}
@@ -15,7 +16,8 @@
 </View>
 
 <View name="secondary">
-  <Select secondary name="Test">
+  <Select secondary name="Test" label="Flavour">
+    <option value="">Choose an option</option>
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}
@@ -23,7 +25,8 @@
 </View>
 
 <View name="outline">
-  <Select outline name="Test">
+  <Select outline name="Test" label="Flavour">
+    <option value="">Choose an option</option>
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}
@@ -31,7 +34,8 @@
 </View>
 
 <View name="disabled">
-  <Select disabled name="Test">
+  <Select disabled name="Test" label="Flavour">
+    <option value="">Choose an option</option>
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}
@@ -39,7 +43,8 @@
 </View>
 
 <View name="thin">
-  <Select thin name="Test">
+  <Select thin name="Test" label="Flavour">
+    <option value="">Choose an option</option>
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}

--- a/src/Form/TextArea.svelte
+++ b/src/Form/TextArea.svelte
@@ -1,14 +1,17 @@
 <script>
   import { createEventDispatcher } from "svelte";
   import Button from "../Button/Button.svelte";
-  const dispatch = createEventDispatcher();
+  import Label from "../Styleguide/Label.svelte";
   import { text_area_resize } from "../actions/autoresize_textarea.js";
+
+  const dispatch = createEventDispatcher();
+
   export let name = false;
   export let label = false;
   export let thin = false;
   export let edit = false;
   export let disabled = false;
-  export let placeholder = false;
+  export let placeholder;
   export let validator = () => {};
   export let value = "";
 
@@ -32,14 +35,18 @@
     flex-direction: column;
   }
 
-  label {
-    color: var(--ink);
-    margin-bottom: 12px;
-    font-family: sans-serif;
+  .label-container {
     display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: var(--spacing-s);
+  }
+  .label-container :global(label) {
+    margin-bottom: 0;
   }
 
-  .right {
+  .controls {
     align-items: center;
     display: grid;
     grid-template-columns: auto auto;
@@ -47,62 +54,62 @@
     margin-left: auto;
     padding-left: 12px;
   }
+  .controls :global(button) {
+    min-width: 100px;
+    font-size: var(--font-size-s);
+    border-radius: var(--rounded-small);
+  }
 
   textarea {
     min-width: 0;
     color: var(--ink);
-    font-size: 18px;
-    font-family: sans-serif;
+    font-size: var(--font-size-s);
+    font-family: var(--font-sans);
     border: none;
-    border-radius: 5px;
+    border-radius: var(--border-radius-s);
     background-color: var(--grey-2);
-    padding: 20px;
+    padding: var(--spacing-m);
     margin: 0;
+    border: var(--border-transparent);
+    outline: none;
   }
-
   textarea::placeholder {
     color: var(--grey-6);
   }
-
-  textarea:focus {
-    box-shadow: 0 4px 16px 0 rgba(57, 60, 68, 0.08);
-  }
-
-  textarea:disabled {
-    background: var(--grey-4);
-  }
-
   textarea.thin {
-    padding: 12px;
-    font-size: 14px;
+    font-size: var(--font-size-xs);
+  }
+  textarea:focus {
+    border: var(--border-blue);
   }
   textarea:disabled {
     background: var(--grey-4);
-    border: none;
+  }
+  textarea:disabled {
+    background: var(--grey-4);
   }
   textarea:disabled::placeholder {
     color: var(--grey-6);
-  }
-  .right :global(button) {
-    min-width: 100px;
-    font-size: var(--font-size-sm);
-    border-radius: var(--rounded-small);
   }
 </style>
 
 <div class="container">
   {#if label || edit}
-    <label class:thin for={name}>
-      {#if label}{label}{/if}
+    <div class="label-container">
+      {#if label}
+        <Label extraSmall grey forAttr={name}>
+          {label}
+        </Label>
+      {/if}
       {#if edit}
-        <div class="right">
+        <div class="controls">
           <Button small secondary disabled={editMode} on:click={enableEdit}>
             Edit
           </Button>
           <Button small blue disabled={!editMode} on:click={save}>Save</Button>
         </div>
       {/if}
-    </label>
+    </div>
   {/if}
   <textarea
     class:thin

--- a/src/Form/TextArea.svench
+++ b/src/Form/TextArea.svench
@@ -6,25 +6,25 @@
 </script>
 
 <View name="default">
-  <TextArea placeholder="Enter your name" label="Name" />
+  <TextArea placeholder="Enter your email text" label="Email Body" />
 </View>
 
 <View name="disabled">
-  <TextArea disabled placeholder="Enter your name" label="Name" />
+  <TextArea disabled placeholder="Enter your email text" label="Email Body" />
 </View>
 
 <View name="no label">
-  <TextArea placeholder="Enter your name" />
+  <TextArea placeholder="Enter your email text" />
 </View>
 
 <View name="thin">
-  <TextArea thin placeholder="Enter your name" label="Name" />
+  <TextArea thin placeholder="Enter your email text" label="Email Body" />
 </View>
 
 <View name="thin">
-  <TextArea thin disabled placeholder="Enter your name" label="Name" />
+  <TextArea thin disabled placeholder="Enter your email text" label="Email Body" />
 </View>
 
 <View name="with buttons">
-  <TextArea edit placeholder="Enter your name" label="Name" />
+  <TextArea edit placeholder="Enter your email text" label="Email Body" />
 </View>

--- a/src/Form/Toggle.svelte
+++ b/src/Form/Toggle.svelte
@@ -1,21 +1,19 @@
 <script>
-  export let id = '';
-  export let text = '';
+  export let name = undefined;
+  export let text = "";
   export let checked = false;
   export let disabled = false;
   export let screenreader = true;
-  
+  export let thin = false;
 </script>
 
 <style>
-
-  label {
-      display: flex;
-      align-items: center;
-      gap: var(--spacing-s);
+  .container {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
   }
-
-  label:disabled {
+  .container:disabled {
     background-color: var(--grey-2);
     cursor: not-allowed;
   }
@@ -27,21 +25,19 @@
     cursor: pointer;
     -webkit-user-select: none; 
     background: transparent;
-    outline-color: var(--blue);
   }
-
 
   .track {
-    width: 28px;
-    height: 14px;
+    width: 32px;
+    height: 18px;
     background-color: var(--grey-4);
-    border-radius: var(--border-radius-xl);
+    border-radius: 9px;
     transition-delay: .12s;
     transition-duration: .2s;
-    transition-property: background,border;
+    transition-property: background;
     transition-timing-function: cubic-bezier(0,0,.2,1);
+    position: relative;
   }
-
 
   .thumb {
     cursor: pointer;
@@ -49,32 +45,27 @@
     transition-duration: .28s;
     transition-property: all;
     transition-timing-function: cubic-bezier(0,0,.2,1);
-    position: absolute;
-    margin: 1px 1px 1px 1.5px;
-    top: 0;
-    left: 0;
-    width: 10px;
-    height: 10px;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
     background-color: white;
     border-radius: var(--border-radius-xl);
-    border: 1px solid transparent;
   }
 
-  input[type='checkbox']:checked ~ .thumb {
-    transform: translateX(115%);
+  input[type='checkbox']:checked ~ .track .thumb {
+    transform: translateX(14px);
   }
   input[type='checkbox']:checked ~ .track {
-     background-color: var(--blue);
-
+    background-color: var(--blue);
   }
   input[type='checkbox']:disabled ~ .track {
     background-color: var(--grey-4);
     cursor: not-allowed;
   }
-  input[type='checkbox']:disabled ~ .thumb {
+  input[type='checkbox']:disabled ~ .track .thumb {
     background-color: var(--grey-2);
     cursor: not-allowed;
-
   }
 
   .screenreader {
@@ -90,24 +81,31 @@
   }
 
   .text {
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-s);
     font-family: var(--font-sans);
     cursor: pointer;
+    user-select: none;
+  }
+  .text.thin {
+    font-size: var(--font-size-xs);
   }
 </style>
 
-<label for="{id}">
-  <span class="text">{text}</span>
+<label for={name} class="container">
   <div class="toggle">
     <input
-      {id}
-      name="{id}"
+      id={name}
+      {name}
       type="checkbox"
       class:screenreader
       {disabled}
       bind:checked
     />
-    <div class="track"></div>
-    <div class="thumb"></div>
+    <div class="track">
+      <div class="thumb"></div>
+    </div>
   </div>
+  {#if text}
+    <span class="text" class:thin>{text}</span>
+  {/if}
 </label>

--- a/src/Form/Toggle.svench
+++ b/src/Form/Toggle.svench
@@ -1,21 +1,21 @@
 <script>
   import { View } from "svench";
   import Toggle from "./Toggle.svelte";
-
-  let nodisplay = false;
-  let display = true;
-
-  $: values = { display, nodisplay };
 </script>
 
 <View name="default">
-  <Toggle bind:checked={nodisplay} id="nodisplay" />
+  <Toggle />
 </View>
 
 <View name="checked with text">
-  <Toggle bind:checked={display} id="display" text="Display on mobile?" />
+  <Toggle text="Display on mobile?" />
+</View>
+
+<View name="thin">
+  <Toggle text="Display on mobile?" thin />
 </View>
 
 <View name="disabled">
-  <Toggle bind:checked={nodisplay} id="disabled" disabled={true} />
+  <Toggle disabled={true} />
 </View>
+

--- a/src/Styleguide/Label.svelte
+++ b/src/Styleguide/Label.svelte
@@ -17,9 +17,8 @@
     text-rendering: var(--text-render);
     color: var(--ink);
     font-size: var(--font-size-s);
-    margin-bottom: 12px;
+    margin-bottom: var(--spacing-s);
     display: block;
-    line-height: 0;
   }
 
   .extraSmall {


### PR DESCRIPTION
This PR standardises styles for all form components and a few others - bringing them all in line with each other. The components affected are: `Input`, `Select`, `TextArea`, `DataList`, and `DatePicker`. `Toggle` has also been updated to at least respect font sizes although its usage is minimal currently. `Label` margin bottom has been reduced from `--spacing-m` from `--spacing-s` to couple better visually with components using them.

These changes provide the following consistencies between these components:
- All render with default font size of `--font-size-s` (14px)
- All accept a `thin` prop to change the font size to `--font-size-xs` (12px)
- All accept a `label` prop with identical styling
- All correctly display `:focus` styling accross browsers `border: var(--border-blue)` (2px solid blue) and have transparent borders when not focused to prevent jumping
- `Inter` font is correctly used for labels and components
- All use padding of `--spacing-m`

All components use labels with props of `extraSmall` and `grey`, provided as part of the standard typography options.
This is equiuvalent to styling of `font-size: 12px`, `color: var(--grey-6)` and `font-weight: 500`.

![labels](https://user-images.githubusercontent.com/9075550/94537963-522dee80-023b-11eb-99ab-1f3d73895e83.PNG)
![labels2](https://user-images.githubusercontent.com/9075550/94537965-52c68500-023b-11eb-8ef5-b075228f344f.PNG)

Focus styling matches the default chrome outline which used to exist, but has now been replaced with borders to achieve rounded cross-browser focus styling.
![focus](https://user-images.githubusercontent.com/9075550/94537955-51955800-023b-11eb-98c5-9730f7bbebb4.PNG)

As a convention moving forward, I would strongly advise making use of the `label` props of form components instead of just placeholders. Placeholders alone can work when using a form that is familiar to the user - like a login form - but a lot of our form components are used to represent complex models and inputs. Placeholders can still be used as well, but I do not believe they are sufficient alone.