### PR TITLE
fix: wrap select and its label inside single parent

### DIFF
--- a/src/Form/Select.svelte
+++ b/src/Form/Select.svelte
@@ -65,21 +65,23 @@
   }
 </style>
 
-{#if label}
-  <Label extraSmall grey forAttr={name}>{label}</Label>
-{/if}
-<div class="relative">
-  <select
-    {name}
-    class:thin
-    class:secondary
-    class:outline
-    {disabled}
-    on:change
-    bind:value>
-    <slot />
-  </select>
-  <div class="pointer">
-    <Icon name="arrowdown" />
+<div>
+  {#if label}
+    <Label extraSmall grey forAttr={name}>{label}</Label>
+  {/if}
+  <div class="relative">
+    <select
+      {name}
+      class:thin
+      class:secondary
+      class:outline
+      {disabled}
+      on:change
+      bind:value>
+      <slot />
+    </select>
+    <div class="pointer">
+      <Icon name="arrowdown" />
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Select labels were rendered top level, but really should be inside a parent container so that they work nicely in grid layouts, the same as the other components.