### PR TITLE
feat: add onchange handler to textarea

### DIFF
--- a/src/Form/TextArea.svelte
+++ b/src/Form/TextArea.svelte
@@ -114,6 +114,7 @@
   <textarea
     class:thin
     bind:value
+    on:change
     disabled={disabled || (edit && !editMode)}
     {placeholder}
     {name}


### PR DESCRIPTION
Text areas should definitely have an `on:change` handler. This adds it.