### PR TITLE
feat: add onchange handler to toggles

### DIFF
--- a/src/Form/Toggle.svelte
+++ b/src/Form/Toggle.svelte
@@ -100,6 +100,7 @@
       class:screenreader
       {disabled}
       bind:checked
+      on:change
     />
     <div class="track">
       <div class="thumb"></div>


### PR DESCRIPTION
Toggles should have an `onchange` handler. This adds it.