### PR TITLE
feat: smaller size options

### DIFF
--- a/src/Form/DataList.svelte
+++ b/src/Form/DataList.svelte
@@ -7,6 +7,7 @@
   export let value = "";
   export let name = undefined;
   export let thin = false;
+  export let extraThin = false;
   export let secondary = false;
   export let outline = false;
   export let disabled = false;
@@ -27,8 +28,6 @@
     focus = false;
     dispatch("blur", e);
   }
-
-  $: console.log(value)
 </script>
 
 <style>
@@ -57,7 +56,7 @@
   select {
     display: block !important;
     width: 100% !important;
-    padding: var(--spacing-m) 2rem var(--spacing-m) var(--spacing-m) !important;
+    padding: var(--spacing-m) 2rem var(--spacing-m) var(--spacing-m);
     appearance: none !important;
     -webkit-appearance: none !important;
     -moz-appearance: none !important;
@@ -79,6 +78,11 @@
   select.thin,
   input.thin {
     font-size: var(--font-size-xs);
+  }
+  select.extraThin,
+  input.extraThin {
+    font-size: var(--font-size-xs);
+    padding: var(--spacing-s) 0 var(--spacing-s) var(--spacing-m);
   }
   .secondary {
     background: var(--grey-2);
@@ -117,6 +121,7 @@
   <select
     {name}
     class:thin
+    class:extraThin
     class:secondary
     {disabled}
     on:change
@@ -128,6 +133,7 @@
   <slot name="custom-input" />
   <input
     class:thin
+    class:extraThin
     class:secondary
     class:disabled
     on:change={updateValue}

--- a/src/Form/DataList.svench
+++ b/src/Form/DataList.svench
@@ -47,4 +47,11 @@
   </DataList>
 </View>
 
+<View name="extraThin">
+  <DataList extraThin name="Test" label="Flavour">
+    {#each options as option}
+      <option value={option}>{option}</option>
+    {/each}
+  </DataList>
+</View>
 

--- a/src/Form/Input.svelte
+++ b/src/Form/Input.svelte
@@ -9,6 +9,7 @@
   export let outline = false;
   export let presentation = false;
   export let thin = false;
+  export let extraThin = false;
   export let large = false;
   export let border = false;
   export let edit = false;
@@ -99,6 +100,10 @@
   input.thin {
     font-size: var(--font-size-xs);
   }
+  input.extraThin {
+    font-size: var(--font-size-xs);
+    padding: var(--spacing-s) var(--spacing-m);
+  }
   input.large {
     font-size: var(--font-size-m);
     padding: var(--spacing-l);
@@ -151,6 +156,7 @@
     class:outline
     class:presentation
     class:thin
+    class:extraThin
     class:large
     class:border
     on:change

--- a/src/Form/Input.svench
+++ b/src/Form/Input.svench
@@ -24,6 +24,10 @@
   <Input thin placeholder="Enter your name" label="Name" />
 </View>
 
+<View name="extraThin">
+  <Input extraThin placeholder="Enter your name" label="Name" />
+</View>
+
 <View name="large">
   <Input large presentation placeholder="Enter your name" label="Name" />
 </View>

--- a/src/Form/Multiselect.svelte
+++ b/src/Form/Multiselect.svelte
@@ -12,6 +12,7 @@
   export let outline = false;
   export let disabled = false;
   export let placeholder = undefined;
+  export let extraThin = false;
 
   let options = [];
   let optionsVisible = false;
@@ -104,11 +105,12 @@
         class:outline
         class:disabled
         class:secondary
+        class:extraThin
         class:optionsVisible
         on:click|self={handleClick}
         class:empty={!value || !value.length}>
         {#each selectedOptions as option}
-          <div class="token" class:secondary data-id={option.value} on:click|self={handleClick}>
+          <div class="token" class:extraThin data-id={option.value} on:click|self={handleClick}>
             <span>{option.name}</span>
             <div
               class="token-remove"
@@ -190,8 +192,7 @@
     flex: 1 1 auto;
     background-color: white;
     border-radius: var(--border-radius-m);
-    padding: 0 var(--spacing-m) calc(var(--spacing-m) - var(--spacing-xs))
-    calc(var(--spacing-m) / 2);
+    padding: 0 var(--spacing-m) calc(var(--spacing-m) - var(--spacing-xs)) calc(var(--spacing-m) / 2);
     border: var(--border-transparent);
   }
   .tokens.disabled {
@@ -204,6 +205,9 @@
   .tokens.secondary {
     background-color: var(--grey-2);
   }
+  .tokens.extraThin {
+    padding: 0 var(--spacing-m) calc(var(--spacing-s) - var(--spacing-xs)) calc(var(--spacing-m) / 2);
+  }
   .tokens:hover {
     cursor: pointer;
   }
@@ -214,6 +218,9 @@
     padding: var(--spacing-m);
     font-size: var(--font-size-xs);
     user-select: none;
+  }
+  .tokens.empty.extraThin {
+    padding: var(--spacing-s) var(--spacing-m);
   }
   .tokens::after {
     width: 100%;
@@ -235,6 +242,10 @@
     transition: background-color 0.3s;
     white-space: nowrap;
     overflow: hidden;
+  }
+  .token.extraThin {
+    margin: calc(var(--spacing-s) - var(--spacing-xs)) 0 0
+    calc(var(--spacing-m) / 2);
   }
   .token span {
     pointer-events: none;

--- a/src/Form/Multiselect.svench
+++ b/src/Form/Multiselect.svench
@@ -36,3 +36,11 @@
     {/each}
   </Multiselect>
 </View>
+
+<View name="extraThin">
+  <Multiselect name="Test" label="Colours" extraThin placeholder="Choose some colours">
+    {#each options as option}
+      <option value={option}>{option}</option>
+    {/each}
+  </Multiselect>
+</View>

--- a/src/Form/Select.svelte
+++ b/src/Form/Select.svelte
@@ -6,6 +6,7 @@
   export let name = undefined;
   export let label = undefined;
   export let thin = false;
+  export let extraThin = false;
   export let secondary = false;
   export let outline = false;
   export let disabled = false;
@@ -32,6 +33,10 @@
   }
   select.thin {
     padding: var(--spacing-m);
+    font-size: var(--font-size-xs);
+  }
+  select.extraThin {
+    padding: var(--spacing-s) 2rem var(--spacing-s) var(--spacing-m) !important;
     font-size: var(--font-size-xs);
   }
   select.secondary {
@@ -73,6 +78,7 @@
     <select
       {name}
       class:thin
+      class:extraThin
       class:secondary
       class:outline
       {disabled}

--- a/src/Form/Select.svench
+++ b/src/Form/Select.svench
@@ -51,4 +51,12 @@
   </Select>
 </View>
 
+<View name="extraThin">
+  <Select extraThin name="Test" label="Flavour">
+    <option value="">Choose an option</option>
+    {#each options as option}
+      <option value={option}>{option}</option>
+    {/each}
+  </Select>
+</View>
 

--- a/src/Form/TextArea.svelte
+++ b/src/Form/TextArea.svelte
@@ -9,6 +9,7 @@
   export let name = false;
   export let label = false;
   export let thin = false;
+  export let extraThin = false;
   export let edit = false;
   export let disabled = false;
   export let placeholder;
@@ -79,6 +80,10 @@
   textarea.thin {
     font-size: var(--font-size-xs);
   }
+  textarea.extraThin {
+    font-size: var(--font-size-xs);
+    padding: var(--spacing-s) var(--spacing-m);
+  }
   textarea:focus {
     border: var(--border-blue);
   }
@@ -113,6 +118,7 @@
   {/if}
   <textarea
     class:thin
+    class:extraThin
     bind:value
     on:change
     disabled={disabled || (edit && !editMode)}

--- a/src/Form/TextArea.svench
+++ b/src/Form/TextArea.svench
@@ -21,8 +21,8 @@
   <TextArea thin placeholder="Enter your email text" label="Email Body" />
 </View>
 
-<View name="thin">
-  <TextArea thin disabled placeholder="Enter your email text" label="Email Body" />
+<View name="extraThin">
+  <TextArea extraThin placeholder="Enter your email text" label="Email Body" />
 </View>
 
 <View name="with buttons">

--- a/src/List/Items/DetailSummary.svelte
+++ b/src/List/Items/DetailSummary.svelte
@@ -1,8 +1,9 @@
 <script>
 	import { createEventDispatcher } from 'svelte';
-  
+
   const dispatch = createEventDispatcher();
 
+  export let thin = false;
   export let name,
     show = false;
 
@@ -21,26 +22,33 @@
     display: flex;
     flex-direction: column;
     height: auto;
-    margin: 0px 0px 4px 0px;
-    padding: 8px 0px;
     justify-content: center;
-    border-radius: 5px;
+    border-radius: var(--border-radius-m);
+    font-family: var(--font-sans);
   }
 
   .property-group-name {
     cursor: pointer;
     display: flex;
     flex-flow: row nowrap;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
   }
 
   .name {
-    flex: 1;
     text-align: left;
-    padding-top: 2px;
     font-size: 14px;
     font-weight: 500;
     letter-spacing: 0.14px;
     color: var(--ink);
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .name.thin {
+    font-size: var(--font-size-xs);
   }
 
   .icon {
@@ -60,12 +68,13 @@
     display: flex;
     flex-direction: column;
     flex: 1;
+    margin-top: var(--spacing-m);
   }
 </style>
 
-<div class="property-group-container">
+<div class="property-group-container" class:thin>
   <div class="property-group-name" on:click={onHeaderClick}>
-    <div class="name">{capitalize(name)}</div>
+    <div class:thin class="name">{capitalize(name)}</div>
     <div class="icon">
       <i class={show ? 'ri-arrow-down-s-fill' : 'ri-arrow-left-s-fill'} />
     </div>

--- a/src/List/Items/DetailSummary.svench
+++ b/src/List/Items/DetailSummary.svench
@@ -3,13 +3,51 @@
   import DetailSummary from "./DetailSummary.svelte";
 </script>
 
+<svelte:head>
+	<link href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" rel="stylesheet">
+</svelte:head>
+
+<style>
+  div {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    gap: var(--spacing-m);
+    width: 120px;
+  }
+</style>
+
 <View name="default">
-  <DetailSummary name="Layout">
-    <ul>
-      <li>1</li>
-      <li>2</li>
-      <li>3</li>
-      <li>4</li>
-    </ul>
-  </DetailSummary>
+  <div>
+    <DetailSummary name="Category 1">
+      <span>1</span>
+      <span>2</span>
+      <span>3</span>
+      <span>4</span>
+    </DetailSummary>
+    <DetailSummary name="Category 2">
+      <span>1</span>
+      <span>2</span>
+      <span>3</span>
+      <span>4</span>
+    </DetailSummary>
+  </div>
+</View>
+
+<View name="thin">
+  <div>
+    <DetailSummary thin name="Category 1">
+      <span>1</span>
+      <span>2</span>
+      <span>3</span>
+      <span>4</span>
+    </DetailSummary>
+    <DetailSummary thin name="Category 2">
+      <span>1</span>
+      <span>2</span>
+      <span>3</span>
+      <span>4</span>
+    </DetailSummary>
+  </div>
 </View>


### PR DESCRIPTION
This PR adds `extraThin` props to all form components which reduces vertical padding. This will be used heavily in the frontend section of the builder to display settings and design options in a compact form.

This also changes DetailView styles to be more flexible.