### PR TITLE
feat: add show and hide events to popovers

### DIFF
--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -1,15 +1,19 @@
 <script>
+  import { createEventDispatcher } from "svelte"
   import buildStyle from "../utils/buildStyle"
+  const dispatch = createEventDispatcher()
 
   export let anchor
   export let align = "right"
 
   export const show = () => {
     open = true
+    dispatch("show")
   }
 
   export const hide = () => {
     open = false
+    dispatch("hide")
   }
 
   let open = null


### PR DESCRIPTION
Adds `show` and `hide` events to popovers so other components can be kept aware of their state. This is required for things like the new component dropdowns - where we want to be aware of when the popover is closed to undo the "active" styling of the category the user had open.