### PR TITLE
feat: add caret position function to text area.

### DIFF
--- a/src/Form/TextArea.svelte
+++ b/src/Form/TextArea.svelte
@@ -15,6 +15,11 @@
   export let placeholder;
   export let validator = () => {};
   export let value = "";
+  export const getCaretPosition = () => {
+    return {start: textarea.selectionStart, end: textarea.selectionEnd};
+  };
+
+  let textarea
 
   // This section handles the edit mode and dispatching of things to the parent when saved
   let editMode = false;
@@ -120,6 +125,7 @@
     class:thin
     class:extraThin
     bind:value
+    bind:this={textarea}
     on:change
     disabled={disabled || (edit && !editMode)}
     {placeholder}


### PR DESCRIPTION
Adds a `getCaretPosition` function to the text area component which can then be used to input text (like binding values) into the text area wherever the caret is.