### PR TITLE
fix: multiselect component change event capability

### DIFF
--- a/src/Form/Multiselect.svelte
+++ b/src/Form/Multiselect.svelte
@@ -1,10 +1,13 @@
 <script>
   import { afterUpdate } from "svelte"
+  import { createEventDispatcher } from "svelte";
   import { fly } from "svelte/transition"
   import Label from "../Styleguide/Label.svelte"
   import buildStyle from "../utils/buildStyle";
   const xPath =
     "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+
+  const dispatch = createEventDispatcher();
 
   export let value = [];
   export let label = undefined;
@@ -65,10 +68,12 @@
 
   function add(val) {
     value = [ ...value, val ];
+    dispatch("change", value)
   }
 
   function remove(val) {
     value = value.filter(option => option !== val);
+    dispatch("change", value)
   }
 
   function showOptions(show) {


### PR DESCRIPTION
Reactive declarations on the multiselect were causing some problems in the builder. This PR allows us to listen to `on:change` for the multiselect for a bit more control